### PR TITLE
fix(rover_hmi_core): publish zero Twist when joystick returns to dead zone

### DIFF
--- a/src/rover_hmi_core/include/rover_hmi_core/drive/drive_module.h
+++ b/src/rover_hmi_core/include/rover_hmi_core/drive/drive_module.h
@@ -67,4 +67,5 @@ private:
     float max_linear_  = 0.5f;   // m/s
     float max_angular_ = 1.0f;   // rad/s
     bool  enabled_     = false;
+    bool  was_moving_  = false;  // last tick published a non-zero Twist
 };

--- a/src/rover_hmi_core/src/drive/drive_module.cpp
+++ b/src/rover_hmi_core/src/drive/drive_module.cpp
@@ -273,7 +273,17 @@ void DriveModule::onPublishTimer() {
     if (!enabled_ || !pub_ || !joystick_) return;
     float x = joystick_->axisX();
     float y = joystick_->axisY();
-    if (std::abs(x) < 0.02f && std::abs(y) < 0.02f) return;  // dead-zone: no-op
+    if (std::abs(x) < 0.02f && std::abs(y) < 0.02f) {
+        // Dead-zone: publish one zero Twist on entry — otherwise the last
+        // non-zero command stays live on the wire after joystick release and
+        // the rover only stops if the consumer happens to run a watchdog.
+        if (was_moving_) {
+            was_moving_ = false;
+            publishTwist(0.0f, 0.0f);
+        }
+        return;
+    }
+    was_moving_ = true;
     publishTwist(y * max_linear_, -x * max_angular_);
 }
 


### PR DESCRIPTION
## Problem

Releasing the HMI's virtual joystick resets the axes, but `onPublishTimer()` early-returned inside the dead zone without publishing anything. The last **non-zero** `cmd_vel` therefore stayed live on the wire after release — the rover only stops if the downstream consumer happens to run its own watchdog. The Space/STOP path already published zeros correctly; mouse release did not.

## Fix

Track whether the previous tick published a non-zero Twist (`was_moving_`) and publish a single zero Twist on dead-zone entry, mirroring what `onKeyStop()` does. The stream then goes quiet as before (no zero-spam at 20 Hz).

## Testing

- `ros2 topic echo /cmd_vel` while dragging + releasing the joystick: exactly one all-zeros Twist arrives on release, then silence.
- Builds clean in the rover container; HMI loads 16/16 modules.

Part of the HMI fixup series — smallest, safety-relevant fix first.