### PR TITLE
Feat/aaronrhim/motor calib per motor

### DIFF
--- a/src/arm_hardware_interface/CMakeLists.txt
+++ b/src/arm_hardware_interface/CMakeLists.txt
@@ -29,6 +29,7 @@ if(BUILD_TESTING)
 endif()
 
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME}/launch)
+install(DIRECTORY config DESTINATION share/${PROJECT_NAME})
 install(DIRECTORY include/ DESTINATION include/)
 
 install(TARGETS moteus_driver

--- a/src/arm_hardware_interface/config/motor_config.yaml
+++ b/src/arm_hardware_interface/config/motor_config.yaml
@@ -1,0 +1,110 @@
+# =============================================================================
+# Per-motor moteus servo parameters — THE single source of truth.
+#
+# Loaded by:
+#   - moteus_driver_node at startup (pushed to firmware via "conf set")
+#   - the HMI "Motor Params" panel, which also WRITES edits back to this file
+#     (through the package share directory; with --symlink-install that write
+#     lands directly here, in the repository)
+#
+# Units: position/velocity in OUTPUT-SHAFT revolutions (firmware applies the
+# gear ratio). timeout_s: .nan means use the firmware default (~0.1 s).
+# gear_reduction is informational only — firmware holds the real value.
+#
+# WHEN TO CHANGE:
+#   kp/kd            — arm oscillates (lower kp / raise kd) or feels sluggish
+#   max_current_a    — motor/driver thermal and hardware limits
+#   position_min/max — software travel limits protecting the arm geometry
+#   max_velocity     — speed cap for safety
+# =============================================================================
+
+motors:
+  motor_1:  # Base
+    kp: 180.0
+    ki: 0.0
+    kd: 40.0
+    max_current_a: 1.0
+    max_velocity: 0.05
+    max_acceleration: 3.0
+    position_min: -0.3
+    position_max: 0.3
+    position_warn_rev_padding: 0.02
+    max_voltage: 26.0
+    max_power_w: 200.0
+    timeout_s: .nan
+    gear_reduction: 0.0052631579  # 1/190
+
+  motor_2:  # Shoulder
+    kp: 2100.0
+    ki: 0.0
+    kd: 100.0
+    max_current_a: 8.0
+    max_velocity: 0.05
+    max_acceleration: 3.0
+    position_min: -0.47
+    position_max: -0.05
+    position_warn_rev_padding: 0.02
+    max_voltage: 26.0
+    max_power_w: 200.0
+    timeout_s: .nan
+    gear_reduction: 0.00625  # 1/160
+
+  motor_3:  # Elbow
+    kp: 4000.0
+    ki: 0.0
+    kd: 750.0
+    max_current_a: 5.5
+    max_velocity: 0.05
+    max_acceleration: 3.0
+    position_min: 0.01
+    position_max: 0.4
+    position_warn_rev_padding: 0.02
+    max_voltage: 26.0
+    max_power_w: 200.0
+    timeout_s: .nan
+    gear_reduction: 0.0083333333  # 1/120
+
+  motor_4:  # Wrist Pitch
+    kp: 50.0
+    ki: 0.0
+    kd: 0.0
+    max_current_a: 0.5
+    max_velocity: 0.05
+    max_acceleration: 3.0
+    position_min: -1.0
+    position_max: 1.0
+    position_warn_rev_padding: 0.02
+    max_voltage: 26.0
+    max_power_w: 200.0
+    timeout_s: .nan
+    gear_reduction: 0.0052631579  # 1/190
+
+  motor_5:  # Wrist Roll
+    kp: 600.0
+    ki: 0.0
+    kd: 100.0
+    max_current_a: 2.5
+    max_velocity: 0.05
+    max_acceleration: 3.0
+    position_min: -999.01  # continuous rotation
+    position_max: 999.4
+    position_warn_rev_padding: 0.02
+    max_voltage: 26.0
+    max_power_w: 200.0
+    timeout_s: .nan
+    gear_reduction: 0.0151515152  # 1/66
+
+  motor_6:  # End Effector
+    kp: 600.0
+    ki: 0.0
+    kd: 100.0
+    max_current_a: 2.5
+    max_velocity: 0.05
+    max_acceleration: 3.0
+    position_min: -999.01  # continuous rotation
+    position_max: 999.4
+    position_warn_rev_padding: 0.02
+    max_voltage: 26.0
+    max_power_w: 200.0
+    timeout_s: .nan
+    gear_reduction: 0.0151515152  # 1/66

--- a/src/arm_hardware_interface/config/motor_config.yaml
+++ b/src/arm_hardware_interface/config/motor_config.yaml
@@ -16,6 +16,11 @@
 #   max_current_a    — motor/driver thermal and hardware limits
 #   position_min/max — software travel limits protecting the arm geometry
 #   max_velocity     — speed cap for safety
+#
+# ⚠ CALIBRATION: every motor needs its OWN measured calibration values, but
+# the `calibration:` blocks below are still identical placeholders (the values
+# historically hardcoded in moteus_driver_node). The HMI's Calibrate buttons
+# are disabled until the real per-motor values are filled in (Aaron).
 # =============================================================================
 
 motors:
@@ -33,6 +38,10 @@ motors:
     max_power_w: 200.0
     timeout_s: .nan
     gear_reduction: 0.0052631579  # 1/190
+    calibration:  # placeholders — real per-motor values TBD (see header)
+      motor_poles: 16
+      force_kv: 265.0
+      use_hall: true
 
   motor_2:  # Shoulder
     kp: 2100.0
@@ -48,6 +57,10 @@ motors:
     max_power_w: 200.0
     timeout_s: .nan
     gear_reduction: 0.00625  # 1/160
+    calibration:  # placeholders — real per-motor values TBD (see header)
+      motor_poles: 16
+      force_kv: 265.0
+      use_hall: true
 
   motor_3:  # Elbow
     kp: 4000.0
@@ -63,6 +76,10 @@ motors:
     max_power_w: 200.0
     timeout_s: .nan
     gear_reduction: 0.0083333333  # 1/120
+    calibration:  # placeholders — real per-motor values TBD (see header)
+      motor_poles: 16
+      force_kv: 265.0
+      use_hall: true
 
   motor_4:  # Wrist Pitch
     kp: 50.0
@@ -78,6 +95,10 @@ motors:
     max_power_w: 200.0
     timeout_s: .nan
     gear_reduction: 0.0052631579  # 1/190
+    calibration:  # placeholders — real per-motor values TBD (see header)
+      motor_poles: 16
+      force_kv: 265.0
+      use_hall: true
 
   motor_5:  # Wrist Roll
     kp: 600.0
@@ -93,6 +114,10 @@ motors:
     max_power_w: 200.0
     timeout_s: .nan
     gear_reduction: 0.0151515152  # 1/66
+    calibration:  # placeholders — real per-motor values TBD (see header)
+      motor_poles: 16
+      force_kv: 265.0
+      use_hall: true
 
   motor_6:  # End Effector
     kp: 600.0
@@ -108,3 +133,7 @@ motors:
     max_power_w: 200.0
     timeout_s: .nan
     gear_reduction: 0.0151515152  # 1/66
+    calibration:  # placeholders — real per-motor values TBD (see header)
+      motor_poles: 16
+      force_kv: 265.0
+      use_hall: true

--- a/src/arm_hardware_interface/include/moteus_driver_node.h
+++ b/src/arm_hardware_interface/include/moteus_driver_node.h
@@ -13,7 +13,8 @@
 //                         URDF joint names, direction signs, unit conversions
 //
 //   motor_config.h      — per-motor PID gains, current limits, position limits
-//                         (the values pushed to firmware on startup)
+//                         (values loaded from this package's
+//                         config/motor_config.yaml, pushed to firmware on startup)
 //
 //   moteus_protocol.h   — what goes in each CAN-FD data field, frame types,
 //                         unit conventions, watchdog notes

--- a/src/arm_hardware_interface/src/moteus_driver_node.cpp
+++ b/src/arm_hardware_interface/src/moteus_driver_node.cpp
@@ -580,13 +580,16 @@ void MoteusDriverNode::runCalibration(int motor_can_id) {
     std::this_thread::sleep_for(100ms);  // small grace period for OS to release the port
 
     // ── Step 4: run moteus_tool, stream output line-by-line to command log ────
+    // Calibration parameters are per-motor, from motor_config.yaml (currently
+    // identical placeholders for every motor — real values TBD).
+    const auto& cal = configs_[motor_can_id - 1];
     std::string cmd =
         "python3 -u -m moteus.moteus_tool"
         " -t " + std::to_string(motor_can_id) +
         " --calibrate"
-        " --cal-motor-poles 16"
-        " --cal-force-kv 265"
-        " --cal-hal"
+        " --cal-motor-poles " + std::to_string(cal.cal_motor_poles) +
+        " --cal-force-kv " + cal.format(cal.cal_force_kv) +
+        (cal.cal_use_hall ? " --cal-hal" : "") +
         " 2>&1";  // merge stderr so we see errors too
 
     publishCalibStatus(motor_can_id, 1,

--- a/src/rover_hmi_core/CMakeLists.txt
+++ b/src/rover_hmi_core/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(ament_index_cpp REQUIRED)
+find_package(yaml-cpp REQUIRED)
 find_package(Qt5 REQUIRED COMPONENTS Core Widgets)
 
 set(CMAKE_AUTOMOC ON)
@@ -21,11 +22,14 @@ include_directories(include)
 add_library(rover_hmi_core SHARED
     src/plot_widget.cpp
     src/tiling_container.cpp
+    src/arm/motor_config_io.cpp
     include/rover_hmi_core/plot_widget.h
     include/rover_hmi_core/tiling_container.h
 )
-target_link_libraries(rover_hmi_core Qt5::Core Qt5::Widgets)
-ament_target_dependencies(rover_hmi_core rclcpp pluginlib)
+# yaml-cpp is PRIVATE: only motor_config_io.cpp touches it, so downstream
+# packages linking rover_hmi_core don't need to find_package it.
+target_link_libraries(rover_hmi_core PUBLIC Qt5::Core Qt5::Widgets PRIVATE yaml-cpp)
+ament_target_dependencies(rover_hmi_core PUBLIC rclcpp pluginlib ament_index_cpp)
 
 target_include_directories(rover_hmi_core PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/src/rover_hmi_core/include/rover_hmi_core/arm/motor_config.h
+++ b/src/rover_hmi_core/include/rover_hmi_core/arm/motor_config.h
@@ -66,6 +66,14 @@ struct MotorConfig {
     // Stored here so the HMI can display it in the Motor Config panel.
     float gear_reduction = 1.0f;
 
+    // Hall calibration parameters passed to moteus_tool by runCalibration().
+    // ⚠ Each motor needs its OWN measured values; the yaml currently carries
+    // identical placeholders for all motors (real values TBD), which is why
+    // the HMI's Calibrate buttons are disabled.
+    int   cal_motor_poles = 16;
+    float cal_force_kv    = 265.0f;
+    bool  cal_use_hall    = true;
+
     // -------------------------------------------------------------------------
     // Helpers used by configureMotor()
     // -------------------------------------------------------------------------

--- a/src/rover_hmi_core/include/rover_hmi_core/arm/motor_config.h
+++ b/src/rover_hmi_core/include/rover_hmi_core/arm/motor_config.h
@@ -14,11 +14,14 @@
 // Defines the per-motor servo parameters pushed to each moteus controller at
 // startup via DiagnosticCommand ("conf set <register> <value>").
 //
-// WHEN TO CHANGE THESE:
-//   - PID gains (kp/kd): if the arm oscillates or feels sluggish
-//   - Current limits: protect motors from overheating / hardware limits
-//   - Position limits: software travel limits to protect the arm geometry
-//   - Velocity limits: cap maximum speed for safety
+// THE VALUES LIVE IN THE REPOSITORY, not in this header:
+//     arm_hardware_interface/config/motor_config.yaml
+// get_arm_configuration() loads that file, resolved through the package share
+// directory — with --symlink-install the share path is a symlink back into
+// src/, so edits made in the HMI's Motor Params panel are written straight to
+// the repo file and the driver picks them up on its next startup.
+// fallback_arm_configuration() holds compiled-in values used only when the
+// YAML cannot be found (and by the HMI's per-row ↺ reset).
 //
 // HOW THEY ARE APPLIED:
 //   1. On node startup, configureMotors() calls configureMotor() for each axis.
@@ -92,11 +95,12 @@ struct MotorConfig {
 
 
 // =============================================================================
-// Per-axis configuration values — edit this function to tune the arm.
+// Compiled-in fallback — used when motor_config.yaml cannot be loaded and by
+// the HMI's ↺ reset. To TUNE the arm edit motor_config.yaml, not this.
 // Each index corresponds to ARM_JOINTS[i] in motor_addressing.h.
 // =============================================================================
 
-inline std::vector<MotorConfig> get_arm_configuration() {
+inline std::vector<MotorConfig> fallback_arm_configuration() {
     std::vector<MotorConfig> axes(NUM_MOTORS);
 
     // --- PID gains (hand-tuned per axis) ---
@@ -134,3 +138,26 @@ inline std::vector<MotorConfig> get_arm_configuration() {
 
     return axes;
 }
+
+
+// =============================================================================
+// YAML-backed accessors — implemented in motor_config_io.cpp (librover_hmi_core)
+// =============================================================================
+
+// Resolved path of arm_hardware_interface/config/motor_config.yaml in the
+// package share directory ("" if the package is not in the ament index).
+std::string motor_config_yaml_path();
+
+// True when the share-dir file is a symlink (i.e. --symlink-install), so
+// writes actually land in the repository. The HMI warns when this is false.
+bool motor_config_yaml_in_repo();
+
+// Per-axis configuration loaded from motor_config.yaml. Falls back to
+// fallback_arm_configuration() (with a stderr warning) if the file is missing
+// or unreadable; individual missing keys fall back per-field.
+std::vector<MotorConfig> get_arm_configuration();
+
+// Rewrite a single "<key>: <value>" line inside the motor_<idx+1> block of
+// motor_config.yaml, preserving comments and layout. Returns false if the
+// file or the key line cannot be found (caller should surface the failure).
+bool save_motor_config_value(int motor_idx, const std::string& key, float value);

--- a/src/rover_hmi_core/package.xml
+++ b/src/rover_hmi_core/package.xml
@@ -16,6 +16,7 @@
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>ament_index_cpp</depend>
+  <depend>yaml-cpp</depend>
 
   <build_depend>qt5-qmake</build_depend>
   <build_depend>qtbase5-dev</build_depend>

--- a/src/rover_hmi_core/src/arm/motor_config_io.cpp
+++ b/src/rover_hmi_core/src/arm/motor_config_io.cpp
@@ -1,0 +1,162 @@
+// motor_config_io.cpp
+//
+// YAML-backed implementation of the motor configuration accessors declared in
+// motor_config.h. The values live in the repository at
+// arm_hardware_interface/config/motor_config.yaml and are resolved through the
+// ament package share directory — with --symlink-install that path is a
+// symlink into src/, so save_motor_config_value() writes straight to the repo.
+
+#include <rover_hmi_core/arm/motor_config.h>
+
+#include <ament_index_cpp/get_package_share_directory.hpp>
+#include <yaml-cpp/yaml.h>
+
+#include <cctype>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+namespace {
+
+float fieldOr(const YAML::Node& motor, const char* key, float fallback) {
+    if (!motor || !motor[key]) return fallback;
+    try {
+        return motor[key].as<float>();
+    } catch (const std::exception&) {
+        return fallback;
+    }
+}
+
+std::string formatValue(float value) {
+    if (std::isnan(value)) return ".nan";
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "%.9g", value);
+    return buf;
+}
+
+size_t indentOf(const std::string& line) {
+    size_t i = 0;
+    while (i < line.size() && line[i] == ' ') ++i;
+    return i;
+}
+
+bool isBlankOrComment(const std::string& line) {
+    size_t i = indentOf(line);
+    return i >= line.size() || line[i] == '#' || line[i] == '\r';
+}
+
+}  // namespace
+
+std::string motor_config_yaml_path() {
+    try {
+        return ament_index_cpp::get_package_share_directory("arm_hardware_interface")
+               + "/config/motor_config.yaml";
+    } catch (const std::exception&) {
+        return {};
+    }
+}
+
+bool motor_config_yaml_in_repo() {
+    std::error_code ec;
+    const std::string path = motor_config_yaml_path();
+    return !path.empty() && std::filesystem::is_symlink(path, ec);
+}
+
+std::vector<MotorConfig> get_arm_configuration() {
+    auto axes = fallback_arm_configuration();
+    const std::string path = motor_config_yaml_path();
+
+    YAML::Node root;
+    try {
+        root = YAML::LoadFile(path);
+    } catch (const std::exception& e) {
+        std::cerr << "[motor_config] WARNING: could not load " << path << " ("
+                  << e.what() << ") — using compiled-in fallback values\n";
+        return axes;
+    }
+
+    const YAML::Node motors = root["motors"];
+    if (!motors) {
+        std::cerr << "[motor_config] WARNING: no 'motors:' map in " << path
+                  << " — using compiled-in fallback values\n";
+        return axes;
+    }
+
+    for (int i = 0; i < NUM_MOTORS; ++i) {
+        const YAML::Node m = motors["motor_" + std::to_string(i + 1)];
+        if (!m) {
+            std::cerr << "[motor_config] WARNING: motor_" << (i + 1)
+                      << " missing from " << path << " — fallback values kept\n";
+            continue;
+        }
+        auto& a = axes[i];
+        a.kp                        = fieldOr(m, "kp", a.kp);
+        a.ki                        = fieldOr(m, "ki", a.ki);
+        a.kd                        = fieldOr(m, "kd", a.kd);
+        a.max_current_A             = fieldOr(m, "max_current_a", a.max_current_A);
+        a.max_velocity              = fieldOr(m, "max_velocity", a.max_velocity);
+        a.max_acceleration          = fieldOr(m, "max_acceleration", a.max_acceleration);
+        a.position_min              = fieldOr(m, "position_min", a.position_min);
+        a.position_max              = fieldOr(m, "position_max", a.position_max);
+        a.position_warn_rev_padding = fieldOr(m, "position_warn_rev_padding",
+                                              a.position_warn_rev_padding);
+        a.max_voltage               = fieldOr(m, "max_voltage", a.max_voltage);
+        a.max_power_W               = fieldOr(m, "max_power_w", a.max_power_W);
+        a.def_timeout               = fieldOr(m, "timeout_s", a.def_timeout);
+        a.gear_reduction            = fieldOr(m, "gear_reduction", a.gear_reduction);
+    }
+    return axes;
+}
+
+bool save_motor_config_value(int motor_idx, const std::string& key, float value) {
+    const std::string path = motor_config_yaml_path();
+    if (path.empty()) return false;
+
+    std::ifstream in(path);
+    if (!in.is_open()) return false;
+    std::vector<std::string> lines;
+    for (std::string line; std::getline(in, line);) lines.push_back(line);
+    in.close();
+
+    const std::string motor_tag = "motor_" + std::to_string(motor_idx + 1) + ":";
+    const std::string key_tag   = key + ":";
+
+    // Locate the motor block, then the key line within it (the block ends at
+    // the first non-blank line indented at or above the block header).
+    size_t block_indent = 0;
+    bool   in_block     = false;
+    for (size_t i = 0; i < lines.size(); ++i) {
+        const std::string& line = lines[i];
+        const size_t indent = indentOf(line);
+
+        if (!in_block) {
+            if (line.compare(indent, motor_tag.size(), motor_tag) == 0) {
+                in_block     = true;
+                block_indent = indent;
+            }
+            continue;
+        }
+
+        if (!isBlankOrComment(line) && indent <= block_indent) break;  // block ended
+        if (line.compare(indent, key_tag.size(), key_tag) != 0) continue;
+
+        // Preserve any trailing comment on the value line.
+        std::string trailing;
+        const size_t hash = line.find('#', indent + key_tag.size());
+        if (hash != std::string::npos) trailing = "  " + line.substr(hash);
+
+        lines[i] = line.substr(0, indent) + key_tag + " " + formatValue(value) + trailing;
+
+        // Rewrite in place — no temp-file+rename, which would replace the
+        // share-dir symlink with a plain file instead of writing through it
+        // into the repository.
+        std::ofstream out(path, std::ios::trunc);
+        if (!out.is_open()) return false;
+        for (const auto& l : lines) out << l << "\n";
+        return out.good();
+    }
+    return false;
+}

--- a/src/rover_hmi_core/src/arm/motor_config_io.cpp
+++ b/src/rover_hmi_core/src/arm/motor_config_io.cpp
@@ -107,6 +107,16 @@ std::vector<MotorConfig> get_arm_configuration() {
         a.max_power_W               = fieldOr(m, "max_power_w", a.max_power_W);
         a.def_timeout               = fieldOr(m, "timeout_s", a.def_timeout);
         a.gear_reduction            = fieldOr(m, "gear_reduction", a.gear_reduction);
+
+        if (const YAML::Node cal = m["calibration"]) {
+            a.cal_motor_poles = static_cast<int>(fieldOr(cal, "motor_poles",
+                                                         (float)a.cal_motor_poles));
+            a.cal_force_kv    = fieldOr(cal, "force_kv", a.cal_force_kv);
+            if (cal["use_hall"]) {
+                try { a.cal_use_hall = cal["use_hall"].as<bool>(); }
+                catch (const std::exception&) {}
+            }
+        }
     }
     return axes;
 }

--- a/src/rover_hmi_core/src/arm/motor_config_module.cpp
+++ b/src/rover_hmi_core/src/arm/motor_config_module.cpp
@@ -97,6 +97,14 @@ static const char* YAML_KEYS[] = {
     nullptr,
 };
 
+// The per-motor calibration blocks in motor_config.yaml are still identical
+// placeholders — running calibration would apply the same (possibly wrong)
+// values to every motor. Flip to true once the real per-motor values land.
+static constexpr bool CALIBRATION_UI_ENABLED = false;
+static const char* CALIBRATION_DISABLED_NOTE =
+    "Disabled: per-motor calibration values in motor_config.yaml are still\n"
+    "identical placeholders — fill in real values per motor first.";
+
 static const int PRECISION[] = { 0, 3, 0, 1, 4, 3, 3, 3, 1, 1, 3, 0 };
 
 static const char* JOINT_NAMES[] = {
@@ -299,12 +307,13 @@ QWidget* MotorConfigModule::createWidget(QWidget* parent) {
         auto* cal_btn = new QPushButton("Calibrate");
         cal_btn->setFont(monoBold);
         cal_btn->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-        cal_btn->setToolTip(
-            QString("Run Hall calibration for %1\n"
-                    "  python3 -m moteus.moteus_tool -t %2\n"
-                    "    --calibrate --cal-motor-poles 16 --cal-force-kv 265 --cal-hal\n"
-                    "then sets motor_position.sources.0.type = type.hall:4")
-            .arg(JOINT_NAMES[r]).arg(r + 1));
+        cal_btn->setEnabled(CALIBRATION_UI_ENABLED);
+        cal_btn->setToolTip(CALIBRATION_UI_ENABLED
+            ? QString("Run Hall calibration for %1 with the calibration values\n"
+                      "from motor_config.yaml, then set\n"
+                      "motor_position.sources.0.type = type.hall:4")
+              .arg(JOINT_NAMES[r])
+            : QString(CALIBRATION_DISABLED_NOTE));
         cal_btn->setStyleSheet(
             QString("QPushButton { background: %1; color: %2;"
                     "  border: 1px solid %3; border-radius: 4px; padding: 5px 10px; }"
@@ -328,9 +337,11 @@ QWidget* MotorConfigModule::createWidget(QWidget* parent) {
     calib_all_btn_->setFont(monoBold);
     calib_all_btn_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     bold_ws.push_back(calib_all_btn_);
-    calib_all_btn_->setToolTip(
-        "Calibrate all 6 motors one by one (motor 1 → 6).\n"
-        "Each takes ~30 s.  The arm driver will pause during calibration.");
+    calib_all_btn_->setEnabled(CALIBRATION_UI_ENABLED);
+    calib_all_btn_->setToolTip(CALIBRATION_UI_ENABLED
+        ? "Calibrate all 6 motors one by one (motor 1 → 6).\n"
+          "Each takes ~30 s.  The arm driver will pause during calibration."
+        : CALIBRATION_DISABLED_NOTE);
     calib_all_btn_->setStyleSheet(
         QString("QPushButton { background: #1a1400; color: %1;"
                 "  border: 1px solid %1; border-radius: 4px; padding: 6px 14px; }"
@@ -559,6 +570,7 @@ void MotorConfigModule::resetMotorToDefaults(int motor_idx) {
 // ---------------------------------------------------------------------------
 
 void MotorConfigModule::requestCalibration(int motor_id) {
+    if (!CALIBRATION_UI_ENABLED) return;  // buttons are disabled; belt-and-braces
     if (!calib_pub_) return;
 
     rover_msgs::msg::MoteusCalibrationRequest msg;
@@ -602,7 +614,7 @@ void MotorConfigModule::onCalibStatus(
                       const char* fg, bool enabled) {
         if (!btn) return;
         btn->setText(text);
-        btn->setEnabled(enabled);
+        btn->setEnabled(enabled && CALIBRATION_UI_ENABLED);
         btn->setStyleSheet(
             QString("QPushButton { background: %1; color: %2;"
                     "  border: 1px solid %3; border-radius: 4px; padding: 5px 10px; }"

--- a/src/rover_hmi_core/src/arm/motor_config_module.cpp
+++ b/src/rover_hmi_core/src/arm/motor_config_module.cpp
@@ -3,27 +3,23 @@
 // Edit flow:
 //   Click cell → cyan border.  Type value.  Enter (or blur) →
 //     1. Published to /arm/config_update  (driver applies to RAM immediately)
-//     2. Saved to QSettings               (survives HMI and driver restarts)
-//     3. Status bar shows what was sent.
-//
-// Load flow (start()):
-//   For every (motor, register) that has been saved, publish a
-//   MoteusConfigUpdate.  This re-applies user customisations on top of the
-//   driver's motor_config.h defaults each time the HMI starts.
+//     2. Written to arm_hardware_interface/config/motor_config.yaml — the
+//        repo-tracked file the driver also loads at startup, so the edit
+//        survives HMI and driver restarts AND shows up in git diff.
+//     3. Status bar shows what was sent (or that the file write failed).
 //
 // Reset flow (↺ button):
-//   Clears all QSettings for that motor and publishes motor_config.h defaults
-//   for every register.  Does NOT save the defaults (so the slot stays clean).
+//   Writes the compiled-in fallback defaults for that motor back into
+//   motor_config.yaml and publishes them so the driver applies immediately.
 
 #include "motor_config_module.h"
-#include "motor_config.h"           // get_arm_configuration(), MotorConfig
+#include "motor_config.h"           // get_arm_configuration(), yaml accessors
 #include <rover_hmi_core/catppuccin.h>
 
 #include <QApplication>
 #include <QGridLayout>
 #include <QScrollArea>
 #include <QFont>
-#include <QSettings>
 #include <cmath>
 #include <algorithm>
 #include <vector>
@@ -92,16 +88,20 @@ static const char* REGISTERS[] = {
 };
 static constexpr int NUM_COLS = 12;
 
+// motor_config.yaml key for each column (parallel to REGISTERS).
+static const char* YAML_KEYS[] = {
+    "kp", "ki", "kd",
+    "max_current_a", "max_velocity", "max_acceleration",
+    "position_min", "position_max",
+    "max_voltage", "max_power_w", "timeout_s",
+    nullptr,
+};
+
 static const int PRECISION[] = { 0, 3, 0, 1, 4, 3, 3, 3, 1, 1, 3, 0 };
 
 static const char* JOINT_NAMES[] = {
     "Base", "Shoulder", "Elbow", "Wrist Pitch", "Wrist Roll", "End Effector"
 };
-
-// QSettings group/key helpers
-static QString settingsKey(int motor_idx, const char* reg) {
-    return QString("motor_params/motor_%1/%2").arg(motor_idx).arg(reg);
-}
 
 // ---------------------------------------------------------------------------
 // Styles
@@ -122,7 +122,7 @@ static QString activeStyle() {
 }
 
 static QString savedStyle() {
-    // Cells with a user QSettings override: cyan text on black — no blue background
+    // Cells edited this session (saved to motor_config.yaml): cyan on black
     return QString(
         "QLineEdit { background: %1; color: %2;"
         "  border: 1px solid %3; padding: 5px 8px; }")
@@ -191,7 +191,7 @@ QWidget* MotorConfigModule::createWidget(QWidget* parent) {
     // No header labels for Reset / Calibrate columns — the buttons are self-explanatory.
 
     // ── Motor rows ────────────────────────────────────────────────────────────
-    QSettings settings("RoverTeam", "RoverHMI");
+    // Values come from motor_config.yaml (the repo file the driver also loads).
     auto arm_defaults = get_arm_configuration();
 
     for (int r = 0; r < NUM_MOTORS; r++) {
@@ -235,17 +235,10 @@ QWidget* MotorConfigModule::createWidget(QWidget* parent) {
                     ? QString("1/%1").arg(qRound(1.0f / def.gear_reduction))
                     : "--");
             } else {
-                // Populate from QSettings override if present, otherwise use default
-                bool has_override = settings.contains(settingsKey(r, REGISTERS[c]));
-                float display_val = has_override
-                    ? settings.value(settingsKey(r, REGISTERS[c])).toFloat()
-                    : motor_defaults[c];
-
+                float display_val = motor_defaults[c];
                 edit->setText(std::isnan(display_val) ? "nan"
                     : QString::number(display_val, 'f', PRECISION[c]));
-                edit->setStyleSheet(has_override
-                    ? savedStyle()
-                    : roStyle(theme::Bg, theme::Text));
+                edit->setStyleSheet(roStyle(theme::Bg, theme::Text));
 
                 // Focus visual feedback.
                 // Guard old_w != nullptr: Qt auto-focuses the first widget on startup
@@ -283,7 +276,9 @@ QWidget* MotorConfigModule::createWidget(QWidget* parent) {
         auto* rst_btn = new QPushButton("↺");
         rst_btn->setFont(monoBold);
         rst_btn->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-        rst_btn->setToolTip(QString("Reset %1 to motor_config.h defaults").arg(JOINT_NAMES[r]));
+        rst_btn->setToolTip(
+            QString("Reset %1 to built-in defaults (writes motor_config.yaml)")
+            .arg(JOINT_NAMES[r]));
         rst_btn->setStyleSheet(
             QString("QPushButton { background: %1; color: %2;"
                     "  border: 1px solid %3; border-radius: 4px; padding: 5px 10px; }"
@@ -350,8 +345,8 @@ QWidget* MotorConfigModule::createWidget(QWidget* parent) {
 
     // Status bar
     status_ = new QLabel(
-        "Click any cell to edit  ·  Enter to apply + save  ·  ↺ to reset row to defaults"
-        "  ·  cyan = user override active");
+        "Click any cell to edit  ·  Enter to apply + write motor_config.yaml"
+        "  ·  ↺ to reset row to defaults  ·  cyan = edited this session");
     status_->setFont(mono);
     status_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     status_->setStyleSheet(
@@ -405,32 +400,21 @@ void MotorConfigModule::setNode(rclcpp::Node::SharedPtr node) {
 }
 
 // ---------------------------------------------------------------------------
-// start()  — re-apply saved overrides after the window is shown
+// start()  — warn if edits won't reach the repository
 // ---------------------------------------------------------------------------
+// The driver reads motor_config.yaml itself at startup, so there is nothing to
+// re-apply here; edits published while both run keep them in sync live.
 
 void MotorConfigModule::start() {
-    if (!pub_) return;
-
-    QSettings settings("RoverTeam", "RoverHMI");
-    int n_applied = 0;
-
-    for (int r = 0; r < NUM_MOTORS; r++) {
-        for (int c = 0; c < NUM_EDITABLE; c++) {
-            if (REGISTERS[c] == nullptr) continue;
-            QString key = settingsKey(r, REGISTERS[c]);
-            if (!settings.contains(key)) continue;
-
-            float val = settings.value(key).toFloat();
-            publishRaw(r, REGISTERS[c], val);
-            ++n_applied;
-        }
-    }
-
-    if (status_ && n_applied > 0) {
+    if (!status_) return;
+    if (!motor_config_yaml_in_repo()) {
         status_->setText(
-            QString("Restored %1 saved override%2 from previous session  ·  "
-                    "cyan tint = user override active")
-            .arg(n_applied).arg(n_applied == 1 ? "" : "s"));
+            QString("⚠ %1 is not a symlink into the repo — edits will NOT be "
+                    "git-tracked (rebuild with --symlink-install)")
+            .arg(QString::fromStdString(motor_config_yaml_path())));
+        status_->setStyleSheet(
+            QString("background: %1; color: %2; padding: 4px 6px;")
+            .arg(theme::Bg).arg(theme::Yellow));
     }
 }
 
@@ -441,8 +425,6 @@ void MotorConfigModule::start() {
 void MotorConfigModule::onFeedback(const rover_msgs::msg::MoteusArmStatus::SharedPtr msg) {
     if (!edits_[0][0]) return;
     if ((int)msg->config.size() < NUM_MOTORS) return;
-
-    QSettings settings("RoverTeam", "RoverHMI");
 
     for (int r = 0; r < NUM_MOTORS; r++) {
         if (r >= (int)msg->config.size()) break;
@@ -473,21 +455,13 @@ void MotorConfigModule::onFeedback(const rover_msgs::msg::MoteusArmStatus::Share
                 float v = vals[col];
                 edit->setText(std::isnan(v) ? "nan"
                     : QString::number(v, 'f', PRECISION[col]));
-
-                // Keep the saved-override tint correct
-                if (REGISTERS[col]) {
-                    bool saved = settings.contains(settingsKey(r, REGISTERS[col]));
-                    if (!edit->hasFocus())
-                        edit->setStyleSheet(saved ? savedStyle()
-                                                  : roStyle(theme::Bg, theme::Text));
-                }
             }
         }
     }
 }
 
 // ---------------------------------------------------------------------------
-// publishUpdate  — send update AND save to QSettings
+// publishUpdate  — send update AND write it to motor_config.yaml
 // ---------------------------------------------------------------------------
 
 void MotorConfigModule::publishUpdate(int motor_idx, int col, float value) {
@@ -495,25 +469,32 @@ void MotorConfigModule::publishUpdate(int motor_idx, int col, float value) {
 
     publishRaw(motor_idx, REGISTERS[col], value);
 
-    // Persist
-    QSettings settings("RoverTeam", "RoverHMI");
-    settings.setValue(settingsKey(motor_idx, REGISTERS[col]), value);
+    // Persist to the repo-tracked yaml (also read by the driver at startup)
+    bool saved = save_motor_config_value(motor_idx, YAML_KEYS[col], value);
 
     // Update cell tint
     if (edits_[motor_idx][col])
         edits_[motor_idx][col]->setStyleSheet(savedStyle());
 
     if (status_) {
-        status_->setText(
-            QString("Saved + applied:  motor %1  %2 = %3")
-            .arg(motor_idx + 1)
-            .arg(REGISTERS[col])
-            .arg(value, 0, 'f', PRECISION[col]));
+        if (saved) {
+            status_->setText(
+                QString("Applied + written to motor_config.yaml:  motor %1  %2 = %3")
+                .arg(motor_idx + 1)
+                .arg(REGISTERS[col])
+                .arg(value, 0, 'f', PRECISION[col]));
+        } else {
+            status_->setText(
+                QString("⚠ Applied to driver but FAILED to write %1 (motor %2  %3)")
+                .arg(QString::fromStdString(motor_config_yaml_path()))
+                .arg(motor_idx + 1)
+                .arg(REGISTERS[col]));
+        }
     }
 }
 
 // ---------------------------------------------------------------------------
-// publishRaw  — send update WITHOUT saving to QSettings
+// publishRaw  — send update WITHOUT touching motor_config.yaml
 // ---------------------------------------------------------------------------
 
 void MotorConfigModule::publishRaw(int motor_idx, const char* reg, float value) {
@@ -526,43 +507,49 @@ void MotorConfigModule::publishRaw(int motor_idx, const char* reg, float value) 
 }
 
 // ---------------------------------------------------------------------------
-// resetMotorToDefaults  — clear saves and re-publish motor_config.h values
+// resetMotorToDefaults  — write built-in defaults to motor_config.yaml and
+// publish them so the driver applies immediately
 // ---------------------------------------------------------------------------
 
 void MotorConfigModule::resetMotorToDefaults(int motor_idx) {
-    auto defaults = get_arm_configuration();
+    auto defaults = fallback_arm_configuration();
     if (motor_idx < 0 || motor_idx >= (int)defaults.size()) return;
     const auto& def = defaults[motor_idx];
 
-    // Clear all saved overrides for this motor
-    QSettings settings("RoverTeam", "RoverHMI");
-    settings.beginGroup(QString("motor_params/motor_%1").arg(motor_idx));
-    settings.remove("");  // removes every key under this group
-    settings.endGroup();
+    const float def_vals[NUM_COLS] = {
+        def.kp, def.ki, def.kd,
+        def.max_current_A,
+        def.max_velocity,
+        def.max_acceleration,
+        def.position_min,
+        def.position_max,
+        def.max_voltage,
+        def.max_power_W,
+        def.def_timeout,
+        def.gear_reduction,  // col 11 — display only, never written
+    };
 
-    // Publish defaults (not saved — QSettings slot is now empty)
-    publishRaw(motor_idx, "servo.pid_position.kp",        def.kp);
-    publishRaw(motor_idx, "servo.pid_position.ki",        def.ki);
-    publishRaw(motor_idx, "servo.pid_position.kd",        def.kd);
-    publishRaw(motor_idx, "servo.max_current_A",          def.max_current_A);
-    publishRaw(motor_idx, "servo.max_velocity",           def.max_velocity);
-    publishRaw(motor_idx, "servo.default_accel_limit",    def.max_acceleration);
-    publishRaw(motor_idx, "servopos.position_min",        def.position_min);
-    publishRaw(motor_idx, "servopos.position_max",        def.position_max);
-    publishRaw(motor_idx, "servo.max_voltage",            def.max_voltage);
-    publishRaw(motor_idx, "servo.max_power_W",            def.max_power_W);
-    publishRaw(motor_idx, "servo.default_timeout_s",      def.def_timeout);
+    bool all_saved = true;
+    for (int col = 0; col < NUM_COLS; col++) {
+        if (REGISTERS[col] == nullptr) continue;
+        publishRaw(motor_idx, REGISTERS[col], def_vals[col]);
+        if (!save_motor_config_value(motor_idx, YAML_KEYS[col], def_vals[col]))
+            all_saved = false;
+    }
 
-    // Revert cell tint to default (no override)
+    // Revert cell tint
     for (int col = 0; col < NUM_EDITABLE; col++) {
         if (edits_[motor_idx][col] && !edits_[motor_idx][col]->hasFocus())
             edits_[motor_idx][col]->setStyleSheet(roStyle(theme::Bg, theme::Text));
     }
 
     if (status_) {
-        status_->setText(
-            QString("Motor %1 (%2) reset to defaults — saved overrides cleared")
-            .arg(motor_idx + 1).arg(JOINT_NAMES[motor_idx]));
+        status_->setText(all_saved
+            ? QString("Motor %1 (%2) reset to built-in defaults — written to motor_config.yaml")
+              .arg(motor_idx + 1).arg(JOINT_NAMES[motor_idx])
+            : QString("⚠ Motor %1 reset published, but writing %2 failed")
+              .arg(motor_idx + 1)
+              .arg(QString::fromStdString(motor_config_yaml_path())));
     }
 }
 


### PR DESCRIPTION
hmi hmi hmi

- Greyed-out calibration buttons until further notice
- Made all saving mechanism save to motor_config.yaml. Nothing saves outside repo in temp files (like previously).