### PR TITLE
Fix include guard copypaste error in DeathRayMotorControlNode

### DIFF
--- a/src/comms_base_control/include/comms_base_control/death_ray_motor_control.h
+++ b/src/comms_base_control/include/comms_base_control/death_ray_motor_control.h
@@ -1,5 +1,5 @@
-#ifndef DRIVE_CONTROL_H
-#define DRIVE_CONTROL_H
+#ifndef DEATH_RAY_MOTOR_CONTROL_H
+#define DEATH_RAY_MOTOR_CONTROL_H
 
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/float32.hpp"
@@ -23,7 +23,7 @@
 #define DISH_PULSES_PER_DEGREE (DISH_PULSES_PER_REVOLUTION / 360.0f)
 
 /**
- * @brief MotorControlNode controls the stepper motor to rotate the comms dish
+ * @brief DeathRayMotorControlNode controls the stepper motor to rotate the comms dish
  * 
  * Acts as an interface between the rotation commands and the GPIO output
  */

--- a/src/comms_base_control/include/comms_base_control/death_ray_motor_control.h
+++ b/src/comms_base_control/include/comms_base_control/death_ray_motor_control.h
@@ -1,5 +1,4 @@
-#ifndef DEATH_RAY_MOTOR_CONTROL_H
-#define DEATH_RAY_MOTOR_CONTROL_H
+#pragma once
 
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/float32.hpp"
@@ -42,5 +41,3 @@ private:
 
     int steps = 0;
 };
-
-#endif


### PR DESCRIPTION
When I made the DeathRayMotorControlNode (#160 ), I copied the header file from the `drive_control` MotorControlNode as a template to work off of, and just realized that I forgot to update the include guard at the top of the file.

Also clarified the doc comment on the DeathRayControlNode to reflect the new node name while I was at it.