### PR TITLE
Absolute death ray commands and manual zeroing

### DIFF
--- a/src/comms_base_control/include/comms_base_control/death_ray_motor_control.h
+++ b/src/comms_base_control/include/comms_base_control/death_ray_motor_control.h
@@ -54,6 +54,8 @@ enum DeathRayControlMode {
 #define DISH_PULSES_PER_REVOLUTION (STEPPER_PULSES_PER_REVOLUTION * STEPPER_GEAR_RATIO)
 #define DISH_PULSES_PER_DEGREE (DISH_PULSES_PER_REVOLUTION / 360.0f)
 
+#define POSITION_FEEDBACK_PUBLISH_FREQUENCY_MS 200
+
 /**
  * @brief DeathRayMotorControlNode controls the stepper motor to rotate the comms dish
  * 
@@ -70,6 +72,10 @@ private:
 
     rclcpp::Subscription<std_msgs::msg::Empty>::SharedPtr death_ray_zero_sub_;
     void deathRayZeroCallback(const std_msgs::msg::Empty::SharedPtr msg);
+
+    rclcpp::TimerBase::SharedPtr position_feedback_timer_;
+    rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr death_ray_position_pub_;
+    void publishDeathRayPosition();
 
     gpiod_chip* chip;
     gpiod_line* dir_line;

--- a/src/comms_base_control/include/comms_base_control/death_ray_motor_control.h
+++ b/src/comms_base_control/include/comms_base_control/death_ray_motor_control.h
@@ -1,9 +1,42 @@
 #pragma once
 
 #include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/empty.hpp"
 #include "std_msgs/msg/float32.hpp"
 
 #include <gpiod.h>
+
+/**
+ * Enum to define the control mode of the death ray.
+ * For both modes, commands are in the range (-180, 180).
+ * 
+ * ABS: Absolute commands. The dish is assumed to be at position 0
+ *      on node startup (and can be zeroed throughout its runtime).
+ *      Commands take the form of absolute positions relative to 0.
+ * 
+ *      Example: If the dish is at position 20 and you issue the command
+ *      50, it will rotate 30 degrees clockwise until it is at 50 degrees.
+ * 
+ * REL: Relative commands. The node does not need to track where the dish
+ *      currently is, commands are simply the number of degrees to move.
+ *      
+ *      Example: If you issue the command 50, the dish will rotate 50
+ *      degrees clockwise.
+ */
+enum DeathRayControlMode {
+    ABS,
+    REL
+};
+
+/**
+ * Define the current control mode of the death ray.
+ * Uncomment the appropriate line for the desired mode.
+ * 
+ * TODO: A way to switch between modes on-the-fly, to better enable
+ * automatic death ray control (probably after comp).
+ */
+#define DEATH_RAY_CONTROL_MODE DeathRayControlMode::ABS
+// #define DEATH_RAY_CONTROL_MODE DeathRayControlMode::REL
 
 #define GPIO_CHIP_NAME "/dev/gpiochip0"
 
@@ -32,12 +65,16 @@ public:
     ~DeathRayMotorControlNode();
 
 private:
-    rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr death_ray_sub_;
-    void deathRayCommandCallback(const std_msgs::msg::Float32::SharedPtr msg);
+    rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr death_ray_motor_sub_;
+    void deathRayMotorCallback(const std_msgs::msg::Float32::SharedPtr msg);
+
+    rclcpp::Subscription<std_msgs::msg::Empty>::SharedPtr death_ray_zero_sub_;
+    void deathRayZeroCallback(const std_msgs::msg::Empty::SharedPtr msg);
 
     gpiod_chip* chip;
     gpiod_line* dir_line;
     gpiod_line* step_line;
 
+    int position = 0;
     int steps = 0;
 };

--- a/src/comms_base_control/include/comms_base_control/death_ray_motor_control.h
+++ b/src/comms_base_control/include/comms_base_control/death_ray_motor_control.h
@@ -73,7 +73,7 @@ private:
     rclcpp::Subscription<std_msgs::msg::Empty>::SharedPtr death_ray_zero_sub_;
     void deathRayZeroCallback(const std_msgs::msg::Empty::SharedPtr msg);
 
-    rclcpp::TimerBase::SharedPtr position_feedback_timer_;
+    rclcpp::TimerBase::SharedPtr death_ray_position_feedback_timer_;
     rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr death_ray_position_pub_;
     void publishDeathRayPosition();
 

--- a/src/comms_base_control/include/comms_base_control/death_ray_motor_control.h
+++ b/src/comms_base_control/include/comms_base_control/death_ray_motor_control.h
@@ -56,6 +56,8 @@ enum DeathRayControlMode {
 
 #define POSITION_FEEDBACK_PUBLISH_FREQUENCY_MS 200
 
+#define ROS_SUBSCRIBER_QOS 1
+
 /**
  * @brief DeathRayMotorControlNode controls the stepper motor to rotate the comms dish
  * 

--- a/src/comms_base_control/include/comms_base_control/death_ray_motor_control.h
+++ b/src/comms_base_control/include/comms_base_control/death_ray_motor_control.h
@@ -8,11 +8,11 @@
 
 /**
  * Enum to define the control mode of the death ray.
- * For both modes, commands are in the range (-180, 180).
  * 
  * ABS: Absolute commands. The dish is assumed to be at position 0
  *      on node startup (and can be zeroed throughout its runtime).
  *      Commands take the form of absolute positions relative to 0.
+ *      Valid commands are in (-180, 180].
  * 
  *      Example: If the dish is at position 20 and you issue the command
  *      50, it will rotate 30 degrees clockwise until it is at 50 degrees.

--- a/src/comms_base_control/src/death_ray_motor_control.cpp
+++ b/src/comms_base_control/src/death_ray_motor_control.cpp
@@ -66,11 +66,17 @@ void DeathRayMotorControlNode::deathRayMotorCallback(const std_msgs::msg::Float3
     if (DEATH_RAY_CONTROL_MODE == DeathRayControlMode::ABS) {
         float cmd = msg->data;
 
-        bool clockwise = cmd > position;
-        float degrees = std::abs(cmd - position);
-        if (!clockwise) degrees *= -1;
+        if (cmd > position) {
+            gpiod_line_set_value(dir_line, STEPPER_CLOCKWISE_DIRECTION);
+        }
+        else if (cmd < position) {
+            gpiod_line_set_value(dir_line, !STEPPER_CLOCKWISE_DIRECTION);
+        }
 
+        float degrees = std::abs(cmd - position);
         steps = std::round(degrees * DISH_PULSES_PER_DEGREE);
+
+        position = cmd;
     }
     else { // Relative mode
         float cmd = msg->data;

--- a/src/comms_base_control/src/death_ray_motor_control.cpp
+++ b/src/comms_base_control/src/death_ray_motor_control.cpp
@@ -77,6 +77,15 @@ void DeathRayMotorControlNode::deathRayMotorCallback(const std_msgs::msg::Float3
     if (DEATH_RAY_CONTROL_MODE == DeathRayControlMode::ABS) {
         float cmd = msg->data;
 
+        if (cmd <= -180.0 || cmd > 180.0f) {
+            RCLCPP_WARN(
+                this->get_logger(),
+                "Invalid death ray command: %.2f degrees. Commands must be in range (-180, 180].",
+                cmd
+            );
+            return;
+        }
+
         if (cmd > position) {
             gpiod_line_set_value(dir_line, STEPPER_CLOCKWISE_DIRECTION);
         }

--- a/src/comms_base_control/src/death_ray_motor_control.cpp
+++ b/src/comms_base_control/src/death_ray_motor_control.cpp
@@ -32,7 +32,13 @@ DeathRayMotorControlNode::DeathRayMotorControlNode() : Node("death_ray_motor_con
     death_ray_zero_sub_ = this->create_subscription<std_msgs::msg::Empty>(
         "death_ray/zero", rclcpp::QoS(10), std::bind(&DeathRayMotorControlNode::deathRayZeroCallback, this, std::placeholders::_1));
 
-    position_feedback_timer_ = this->create_wall_timer(
+    auto qos = rclcpp::QoS(rclcpp::KeepLast(64));
+    death_ray_position_pub_ = this->create_publisher<std_msgs::msg::Float32>(
+        "death_ray/position",
+        qos
+    );
+    
+    death_ray_position_feedback_timer_ = this->create_wall_timer(
         std::chrono::milliseconds(POSITION_FEEDBACK_PUBLISH_FREQUENCY_MS),
         std::bind(&DeathRayMotorControlNode::publishDeathRayPosition, this)
     );

--- a/src/comms_base_control/src/death_ray_motor_control.cpp
+++ b/src/comms_base_control/src/death_ray_motor_control.cpp
@@ -26,8 +26,11 @@ DeathRayMotorControlNode::DeathRayMotorControlNode() : Node("death_ray_motor_con
         RCLCPP_INFO(this->get_logger(), "Successfully requested STEP line on pin %d", STEP_LINE_GPIO_PIN);
     }
 
-    death_ray_sub_ = this->create_subscription<std_msgs::msg::Float32>(
-        "death_ray_commands", rclcpp::QoS(10), std::bind(&DeathRayMotorControlNode::deathRayCommandCallback, this, std::placeholders::_1));
+    death_ray_motor_sub_ = this->create_subscription<std_msgs::msg::Float32>(
+        "death_ray/motor_commands", rclcpp::QoS(10), std::bind(&DeathRayMotorControlNode::deathRayMotorCallback, this, std::placeholders::_1));
+
+    death_ray_zero_sub_ = this->create_subscription<std_msgs::msg::Empty>(
+        "death_ray/zero", rclcpp::QoS(10), std::bind(&DeathRayMotorControlNode::deathRayZeroCallback, this, std::placeholders::_1));
 
     RCLCPP_INFO(this->get_logger(), "DeathRayMotorControlNode initialization complete.");
 }
@@ -45,7 +48,7 @@ DeathRayMotorControlNode::~DeathRayMotorControlNode() {
 }
 
 /**
- * Callback for the /death_ray_commands subscriber.
+ * Callback for the /death_ray/motor_commands subscriber.
  * Receives and decodes Float32 messages.
  * 
  * The sign of the command indicates the direction 
@@ -57,17 +60,30 @@ DeathRayMotorControlNode::~DeathRayMotorControlNode() {
  * to rotate the dish. This function decodes the command and 
  * transmits it to the GPIO pins.
  */
-void DeathRayMotorControlNode::deathRayCommandCallback(const std_msgs::msg::Float32::SharedPtr msg) {
-    float stepper_cmd = msg->data;
+void DeathRayMotorControlNode::deathRayMotorCallback(const std_msgs::msg::Float32::SharedPtr msg) {
+    int steps;
 
-    if (stepper_cmd > 0) {
-        gpiod_line_set_value(dir_line, STEPPER_CLOCKWISE_DIRECTION);
-    } else if (stepper_cmd < 0) {
-        gpiod_line_set_value(dir_line, !STEPPER_CLOCKWISE_DIRECTION);
+    if (DEATH_RAY_CONTROL_MODE == DeathRayControlMode::ABS) {
+        float cmd = msg->data;
+
+        bool clockwise = cmd > position;
+        float degrees = std::abs(cmd - position);
+        if (!clockwise) degrees *= -1;
+
+        steps = std::round(degrees * DISH_PULSES_PER_DEGREE);
     }
+    else { // Relative mode
+        float cmd = msg->data;
 
-    float degrees = std::abs(stepper_cmd);
-    int steps = std::round(degrees * DISH_PULSES_PER_DEGREE);
+        if (cmd > 0) {
+            gpiod_line_set_value(dir_line, STEPPER_CLOCKWISE_DIRECTION);
+        } else if (cmd < 0) {
+            gpiod_line_set_value(dir_line, !STEPPER_CLOCKWISE_DIRECTION);
+        }
+
+        float degrees = std::abs(cmd);
+        steps = std::round(degrees * DISH_PULSES_PER_DEGREE);
+    }
 
     /**
      * rclcpp::ok on each loop iteration ensures that the loop stops
@@ -82,6 +98,24 @@ void DeathRayMotorControlNode::deathRayCommandCallback(const std_msgs::msg::Floa
         gpiod_line_set_value(step_line, 0);
         std::this_thread::sleep_for(std::chrono::milliseconds(STEPPER_PULSE_DELAY_MS));
     }
+}
+
+/**
+ * Callback for the death_ray/zero subscriber.
+ * 
+ * Sets the current tracked position to 0, for manual homing.
+ */
+void DeathRayMotorControlNode::deathRayZeroCallback(const std_msgs::msg::Empty::SharedPtr msg) {
+    /**
+     * Message content is empty: receiving any message on this topic indicates that the dish
+     * should be zeroed.
+     * 
+     * There doesn't seem to be a way to define a subscriber callback without any parameters,
+     * so this prevents compiler errors due to an unused parameter.
+     */
+    (void) msg;
+
+    position = 0;
 }
 
 int main(int argc, char* argv[]) {

--- a/src/comms_base_control/src/death_ray_motor_control.cpp
+++ b/src/comms_base_control/src/death_ray_motor_control.cpp
@@ -27,10 +27,10 @@ DeathRayMotorControlNode::DeathRayMotorControlNode() : Node("death_ray_motor_con
     }
 
     death_ray_motor_sub_ = this->create_subscription<std_msgs::msg::Float32>(
-        "death_ray/motor_commands", rclcpp::QoS(10), std::bind(&DeathRayMotorControlNode::deathRayMotorCallback, this, std::placeholders::_1));
+        "death_ray/motor_commands", rclcpp::QoS(ROS_SUBSCRIBER_QOS), std::bind(&DeathRayMotorControlNode::deathRayMotorCallback, this, std::placeholders::_1));
 
     death_ray_zero_sub_ = this->create_subscription<std_msgs::msg::Empty>(
-        "death_ray/zero", rclcpp::QoS(10), std::bind(&DeathRayMotorControlNode::deathRayZeroCallback, this, std::placeholders::_1));
+        "death_ray/zero", rclcpp::QoS(ROS_SUBSCRIBER_QOS), std::bind(&DeathRayMotorControlNode::deathRayZeroCallback, this, std::placeholders::_1));
 
     auto qos = rclcpp::QoS(rclcpp::KeepLast(64));
     death_ray_position_pub_ = this->create_publisher<std_msgs::msg::Float32>(

--- a/src/comms_base_control/src/death_ray_motor_control.cpp
+++ b/src/comms_base_control/src/death_ray_motor_control.cpp
@@ -32,6 +32,11 @@ DeathRayMotorControlNode::DeathRayMotorControlNode() : Node("death_ray_motor_con
     death_ray_zero_sub_ = this->create_subscription<std_msgs::msg::Empty>(
         "death_ray/zero", rclcpp::QoS(10), std::bind(&DeathRayMotorControlNode::deathRayZeroCallback, this, std::placeholders::_1));
 
+    position_feedback_timer_ = this->create_wall_timer(
+        std::chrono::milliseconds(POSITION_FEEDBACK_PUBLISH_FREQUENCY_MS),
+        std::bind(&DeathRayMotorControlNode::publishDeathRayPosition, this)
+    );
+
     RCLCPP_INFO(this->get_logger(), "DeathRayMotorControlNode initialization complete.");
 }
 
@@ -122,6 +127,15 @@ void DeathRayMotorControlNode::deathRayZeroCallback(const std_msgs::msg::Empty::
     (void) msg;
 
     position = 0;
+}
+
+/**
+ * Publish the current position of the death ray.
+ */
+void DeathRayMotorControlNode::publishDeathRayPosition() {
+    std_msgs::msg::Float32 msg;
+    msg.data = position;
+    death_ray_position_pub_->publish(msg);
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
Original death ray control interface only supported relative commands (example: the command '20' will rotate the dish 20 degrees clockwise from its current position).

It will be more useful at comp to be able to provide absolute commands. The dish can be zeroed, and commands are interpreted as offsets from 0 direction. For example, the same command '20' will rotate the dish so that its position is 20:
-  If the dish is currently at '40', this means rotating 20 degrees counterclockwise
-  If the dish is currently at '-20', it will rotate 40 degrees clockwise

All commands are in the range (-180, 180], where negative positions are to the left of the zero point, and positive commands are to the right. This is chosen over [0, 360) because reasoning about commands in the (-180, 0) range will be a lot more intuitive than those in the (180, 360) range.

Position is assumed to be 0 on node startup, to allow us to manually point the dish as desired at the start of a task. Zeroing can also be re-done at any time by issuing a message on the "death_ray/zero" topic.

Also added a publisher for the current tracked position of the dish, which may make it easier to figure out which commands to issue if we are doing it manually.